### PR TITLE
feat: add interactive shell with history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "httpx>=0.24.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
+    "prompt_toolkit>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,47 @@
+import typer
+from typer.testing import CliRunner
+
+from pilotcmd.cli import app
+
+
+def test_shell_creates_history(monkeypatch, tmp_path):
+    # Redirect HOME to temporary directory
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    prompts = iter(["echo test", "quit"])
+
+    class DummySession:
+        def __init__(self, *args, history=None, **kwargs):
+            self.history = history
+
+        def prompt(self, *args, **kwargs):
+            try:
+                text = next(prompts)
+            except StopIteration:
+                raise EOFError()
+            if self.history is not None:
+                self.history.append_string(text)
+            return text
+
+    def fake_run_command(
+        ctx,
+        prompt,
+        model=None,
+        dry_run=False,
+        auto_run=False,
+        verbose=False,
+        thinking=False,
+    ):
+        calls.append(prompt)
+
+    calls = []
+    monkeypatch.setattr("pilotcmd.cli.PromptSession", DummySession)
+    monkeypatch.setattr("pilotcmd.cli.run_command", fake_run_command)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["shell"])
+    assert result.exit_code == 0
+    assert calls == ["echo test"]
+    history_file = tmp_path / ".pilotcmd" / "shell_history"
+    assert history_file.exists()
+    assert "echo test" in history_file.read_text()


### PR DESCRIPTION
## Summary
- add session-aware `pilotcmd shell` REPL using prompt_toolkit
- persist shell command history between runs
- test interactive shell history persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ebd1293f883218c2b6c7abc434dd1