### PR TITLE
feat: expand explain command with revert guidance

### DIFF
--- a/src/pilotcmd/cli.py
+++ b/src/pilotcmd/cli.py
@@ -373,6 +373,9 @@ def explain_command(
             )
             return
 
+        # Register prompt and commands in history
+        context_manager.save_prompt(prompt, commands, os_info)
+
         # Show explanation in educational format
         console.print(
             f'[bold blue]📚 Explaining: [/bold blue][italic]"{prompt}"[/italic]'
@@ -381,10 +384,10 @@ def explain_command(
 
         if len(commands) == 1:
             cmd = commands[0]
-            console.print(
-                f"[green]→ This would execute:[/green] [cyan]{cmd.command}[/cyan]"
-            )
-            console.print(f"[green]→ Explanation:[/green] {cmd.explanation}")
+            console.print(f"[green]→ Command:[/green] [cyan]{cmd.command}[/cyan]")
+            console.print(f"[green]→ Why:[/green] {cmd.explanation}")
+            revert_text = cmd.revert or "No revert available"
+            console.print(f"[green]→ Revert:[/green] {revert_text}")
 
             if cmd.requires_sudo:
                 console.print(
@@ -409,7 +412,9 @@ def explain_command(
             )
             for i, cmd in enumerate(commands, 1):
                 console.print(f"  [bold]{i}.[/bold] [cyan]{cmd.command}[/cyan]")
-                console.print(f"     [dim]{cmd.explanation}[/dim]")
+                console.print(f"     [dim]Why:[/dim] {cmd.explanation}")
+                revert_text = cmd.revert or "No revert available"
+                console.print(f"     [dim]Revert:[/dim] {revert_text}")
 
                 if cmd.requires_sudo:
                     console.print(

--- a/src/pilotcmd/models/base.py
+++ b/src/pilotcmd/models/base.py
@@ -67,6 +67,7 @@ RULES:
 6. Use full paths when necessary
 7. Avoid commands that could damage the system
 8. If the request is unclear or potentially dangerous, ask for clarification
+9. Provide a command to revert each step when possible
 
 Response format should be JSON with the following structure:
 {
@@ -75,6 +76,7 @@ Response format should be JSON with the following structure:
       \"step\": number starting from 1,
       \"command\": \"the actual command to execute\",
       \"explanation\": \"brief explanation of what this command does\",
+      \"revert\": \"command to undo or revert if possible\",
       \"safety_level\": \"safe|caution|dangerous\",
       \"requires_sudo\": true/false
     }
@@ -101,6 +103,7 @@ RULES:
 5. Use full paths when necessary
 6. Avoid commands that could damage the system
 7. If the request is unclear or potentially dangerous, ask for clarification
+8. Provide a command to revert each step when possible
 
 Response format should be JSON with the following structure:
 {
@@ -108,6 +111,7 @@ Response format should be JSON with the following structure:
     {
       "command": "the actual command to execute",
       "explanation": "brief explanation of what this command does",
+      "revert": "command to undo or revert if possible",
       "safety_level": "safe|caution|dangerous",
       "requires_sudo": true/false
     }

--- a/src/pilotcmd/nlp/parser.py
+++ b/src/pilotcmd/nlp/parser.py
@@ -27,6 +27,7 @@ class Command:
 
     command: str
     explanation: str
+    revert: Optional[str] = None
     step: Optional[int] = None
     safety_level: SafetyLevel = SafetyLevel.SAFE
     requires_sudo: bool = False
@@ -139,6 +140,7 @@ class NLPParser:
                 command = Command(
                     command=cmd_data.get("command", ""),
                     explanation=cmd_data.get("explanation", ""),
+                    revert=cmd_data.get("revert"),
                     step=cmd_data.get("step"),
                     safety_level=cmd_data.get("safety_level", "safe"),
                     requires_sudo=cmd_data.get("requires_sudo", False),

--- a/src/pilotcmd/nlp/simple_parser.py
+++ b/src/pilotcmd/nlp/simple_parser.py
@@ -10,6 +10,7 @@ from pilotcmd.os_utils.detector import OSInfo
 
 class SafetyLevel:
     """Simple safety level constants."""
+
     SAFE = "safe"
     CAUTION = "caution"
     DANGEROUS = "dangerous"
@@ -17,25 +18,34 @@ class SafetyLevel:
 
 class Command:
     """Simple command class for fallback parser."""
-    def __init__(self, command: str, explanation: str, safety_level: str = "safe", requires_sudo: bool = False):
+
+    def __init__(
+        self,
+        command: str,
+        explanation: str,
+        safety_level: str = "safe",
+        requires_sudo: bool = False,
+        revert: str | None = None,
+    ):
         self.command = command
         self.explanation = explanation
         self.safety_level = safety_level
         self.requires_sudo = requires_sudo
+        self.revert = revert
 
 
 class SimpleParser:
     """Simple pattern-based parser as fallback when AI models fail."""
-    
+
     def __init__(self, os_info: OSInfo):
         self.os_info = os_info
         self.patterns = self._get_patterns()
-    
+
     async def parse(self, prompt: str) -> List[Command]:
         """Parse prompt using simple pattern matching."""
         prompt_lower = prompt.lower().strip()
         commands = []
-        
+
         # Try each pattern
         for pattern_info in self.patterns:
             if self._matches_pattern(prompt_lower, pattern_info):
@@ -43,140 +53,167 @@ class SimpleParser:
                 if cmd:
                     commands.append(cmd)
                     break
-        
+
         # If no pattern matches, return empty list
         return commands
-    
+
     def _matches_pattern(self, prompt: str, pattern_info: Dict[str, Any]) -> bool:
         """Check if prompt matches a pattern."""
-        keywords = pattern_info.get('keywords', [])
+        keywords = pattern_info.get("keywords", [])
         return any(keyword in prompt for keyword in keywords)
-    
+
     def _generate_command(self, prompt: str, pattern_info: Dict[str, Any]) -> Command:
         """Generate command from pattern."""
         if self.os_info.is_windows():
-            cmd = pattern_info.get('windows', '')
+            cmd = pattern_info.get("windows", "")
+            revert_cmd = pattern_info.get("revert_windows", pattern_info.get("revert"))
         elif self.os_info.is_macos():
-            cmd = pattern_info.get('macos', pattern_info.get('unix', ''))
+            cmd = pattern_info.get("macos", pattern_info.get("unix", ""))
+            revert_cmd = pattern_info.get(
+                "revert_macos",
+                pattern_info.get("revert_unix", pattern_info.get("revert")),
+            )
         else:  # Linux
-            cmd = pattern_info.get('linux', pattern_info.get('unix', ''))
-        
+            cmd = pattern_info.get("linux", pattern_info.get("unix", ""))
+            revert_cmd = pattern_info.get(
+                "revert_linux",
+                pattern_info.get("revert_unix", pattern_info.get("revert")),
+            )
+
         if not cmd:
             return None
-        
+
         # Simple parameter extraction
         cmd = self._extract_parameters(prompt, cmd)
-        
+        if revert_cmd:
+            revert_cmd = self._extract_parameters(prompt, revert_cmd)
+        else:
+            revert_cmd = "No revert available"
+
         return Command(
             command=cmd,
-            explanation=pattern_info.get('explanation', f"Execute: {cmd}"),
-            safety_level=pattern_info.get('safety', 'safe'),
-            requires_sudo=pattern_info.get('requires_sudo', False)
+            explanation=pattern_info.get("explanation", f"Execute: {cmd}"),
+            safety_level=pattern_info.get("safety", "safe"),
+            requires_sudo=pattern_info.get("requires_sudo", False),
+            revert=revert_cmd,
         )
-    
+
     def _extract_parameters(self, prompt: str, cmd_template: str) -> str:
         """Extract parameters from prompt and substitute in command template."""
         # Simple parameter extraction
-        if '{file}' in cmd_template:
+        if "{file}" in cmd_template:
             # Try to find file names in prompt
             words = prompt.split()
             for word in words:
-                if '.' in word and not word.startswith('.'):
-                    cmd_template = cmd_template.replace('{file}', word)
+                if "." in word and not word.startswith("."):
+                    cmd_template = cmd_template.replace("{file}", word)
                     break
             else:
-                cmd_template = cmd_template.replace('{file}', '*')
-        
-        if '{target}' in cmd_template:
+                cmd_template = cmd_template.replace("{file}", "*")
+
+        if "{target}" in cmd_template:
             # Try to find IP addresses or hostnames
             words = prompt.split()
             for word in words:
-                if '.' in word and not word.startswith('.'):
-                    cmd_template = cmd_template.replace('{target}', word)
+                if "." in word and not word.startswith("."):
+                    cmd_template = cmd_template.replace("{target}", word)
                     break
             else:
-                cmd_template = cmd_template.replace('{target}', 'google.com')
-        
+                cmd_template = cmd_template.replace("{target}", "google.com")
+
         return cmd_template
-    
+
     def _get_patterns(self) -> List[Dict[str, Any]]:
         """Get list of command patterns."""
         return [
             {
-                'keywords': ['time', 'current time', 'show time', 'what time'],
-                'explanation': 'Show current time',
-                'windows': 'time /t',
-                'unix': 'date',
-                'safety': 'safe'
+                "keywords": ["time", "current time", "show time", "what time"],
+                "explanation": "Show current time",
+                "windows": "time /t",
+                "unix": "date",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['list', 'show', 'files', 'directory', 'folder'],
-                'explanation': 'List directory contents',
-                'windows': 'dir',
-                'unix': 'ls -la',
-                'safety': 'safe'
+                "keywords": ["list", "show", "files", "directory", "folder"],
+                "explanation": "List directory contents",
+                "windows": "dir",
+                "unix": "ls -la",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['current', 'directory', 'where am i', 'pwd'],
-                'explanation': 'Show current directory',
-                'windows': 'cd',
-                'unix': 'pwd',
-                'safety': 'safe'
+                "keywords": ["current", "directory", "where am i", "pwd"],
+                "explanation": "Show current directory",
+                "windows": "cd",
+                "unix": "pwd",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['ping'],
-                'explanation': 'Ping a host',
-                'windows': 'ping {target}',
-                'unix': 'ping -c 4 {target}',
-                'safety': 'safe'
+                "keywords": ["ping"],
+                "explanation": "Ping a host",
+                "windows": "ping {target}",
+                "unix": "ping -c 4 {target}",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['python', 'files', 'find'],
-                'explanation': 'Find Python files',
-                'windows': 'dir *.py /s',
-                'unix': 'find . -name "*.py"',
-                'safety': 'safe'
+                "keywords": ["python", "files", "find"],
+                "explanation": "Find Python files",
+                "windows": "dir *.py /s",
+                "unix": 'find . -name "*.py"',
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['disk', 'space', 'usage', 'free'],
-                'explanation': 'Show disk usage',
-                'windows': 'dir /-c',
-                'unix': 'df -h',
-                'safety': 'safe'
+                "keywords": ["disk", "space", "usage", "free"],
+                "explanation": "Show disk usage",
+                "windows": "dir /-c",
+                "unix": "df -h",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['process', 'running', 'task'],
-                'explanation': 'List running processes',
-                'windows': 'tasklist',
-                'unix': 'ps aux',
-                'safety': 'safe'
+                "keywords": ["process", "running", "task"],
+                "explanation": "List running processes",
+                "windows": "tasklist",
+                "unix": "ps aux",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['ip', 'address', 'network'],
-                'explanation': 'Show IP configuration',
-                'windows': 'ipconfig',
-                'unix': 'ip addr show',
-                'safety': 'safe'
+                "keywords": ["ip", "address", "network"],
+                "explanation": "Show IP configuration",
+                "windows": "ipconfig",
+                "unix": "ip addr show",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['system', 'info', 'information'],
-                'explanation': 'Show system information',
-                'windows': 'systeminfo',
-                'unix': 'uname -a',
-                'safety': 'safe'
+                "keywords": ["system", "info", "information"],
+                "explanation": "Show system information",
+                "windows": "systeminfo",
+                "unix": "uname -a",
+                "safety": "safe",
+                "revert": "No revert needed",
             },
             {
-                'keywords': ['create', 'mkdir', 'folder', 'directory'],
-                'explanation': 'Create directory',
-                'windows': 'mkdir test_folder',
-                'unix': 'mkdir test_folder',
-                'safety': 'safe'
+                "keywords": ["create", "mkdir", "folder", "directory"],
+                "explanation": "Create directory",
+                "windows": "mkdir test_folder",
+                "unix": "mkdir test_folder",
+                "safety": "safe",
+                "revert_windows": "rmdir test_folder",
+                "revert_unix": "rm -r test_folder",
             },
             {
-                'keywords': ['copy', 'cp'],
-                'explanation': 'Copy files',
-                'windows': 'copy {file} backup_{file}',
-                'unix': 'cp {file} backup_{file}',
-                'safety': 'caution'
-            }
+                "keywords": ["copy", "cp"],
+                "explanation": "Copy files",
+                "windows": "copy {file} backup_{file}",
+                "unix": "cp {file} backup_{file}",
+                "safety": "caution",
+                "revert_windows": "del backup_{file}",
+                "revert_unix": "rm backup_{file}",
+            },
         ]

--- a/src/pilotcmd/nlp/simple_parser.py
+++ b/src/pilotcmd/nlp/simple_parser.py
@@ -88,7 +88,7 @@ class SimpleParser:
         if revert_cmd:
             revert_cmd = self._extract_parameters(prompt, revert_cmd)
         else:
-            revert_cmd = "No revert available"
+            revert_cmd = NO_REVERT_AVAILABLE
 
         return Command(
             command=cmd,

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,12 @@
+from typer.testing import CliRunner
+
+from pilotcmd.cli import app
+
+
+def test_explain_shows_revert(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["explain", "create directory"])
+    assert result.exit_code == 0
+    assert "Revert:" in result.stdout


### PR DESCRIPTION
## Summary
- show revert instructions and log prompts in `pilotcmd explain`
- teach parser and system prompts about revert commands
- add test ensuring explain outputs revert info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec2ebc6588321a53d3f323657b768