### PR TITLE
feat: add cross-platform command matrix and package manager detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ PilotCmd is built with a modular architecture:
 - **Context DB**: SQLite database for history and learning
 - **OS Utils**: Cross-platform command adaptation
 
+## 🧭 OS Command Mapping Matrix
+
+PilotCmd automatically adapts commands for Linux, macOS and Windows. The table below highlights common tasks and their platform-specific equivalents along with notes on quirks:
+
+| Task | Linux | macOS | Windows | Notes |
+| --- | --- | --- | --- | --- |
+| List network interfaces | `ip addr show` | `ifconfig` | `ipconfig /all` | |
+| Manage firewall status | `sudo ufw status` / `sudo nft list ruleset` | `sudo pfctl -s all` | `netsh advfirewall show allprofiles` | Linux picks `ufw`, `nft`, or `iptables` if available |
+| Enable firewall | `sudo ufw enable` / `sudo systemctl start nftables` | `sudo pfctl -E` | `netsh advfirewall set allprofiles state on` | |
+| Start service | `systemctl start <svc>` | `launchctl start <svc>` | `sc start <svc>` | `systemctl` vs `sc` |
+| Install package | `sudo apt install` / `sudo dnf install` / `sudo pacman -S` | `brew install` | `winget install` / `choco install` | Package manager auto-detected with fallbacks |
+
 ## 🤝 Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/src/pilotcmd/os_utils/detector.py
+++ b/src/pilotcmd/os_utils/detector.py
@@ -224,7 +224,7 @@ class OSDetector:
         else:
             packages = {}
 
-        firewall_tool = self._os_info.firewall_tool or self._detect_linux_firewall_tool()
+        firewall_tool = self._os_info.firewall_tool
         if firewall_tool == "ufw":
             firewall = {
                 "enable": "sudo ufw enable",

--- a/src/pilotcmd/os_utils/detector.py
+++ b/src/pilotcmd/os_utils/detector.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from enum import Enum
 import platform
 import subprocess
-from typing import Dict, List, Optional
+import shutil
+from typing import Dict, Optional
 
 
 class OSType(Enum):
@@ -26,6 +27,7 @@ class OSInfo:
     architecture: str
     shell: str
     package_manager: Optional[str] = None
+    firewall_tool: Optional[str] = None
     
     def is_windows(self) -> bool:
         return self.type == OSType.WINDOWS
@@ -49,31 +51,36 @@ class OSDetector:
             return self._os_info
         
         system = platform.system().lower()
-        
+
         if system == "windows":
             os_type = OSType.WINDOWS
             shell = self._detect_windows_shell()
             package_manager = self._detect_windows_package_manager()
+            firewall_tool = "netsh"
         elif system == "linux":
             os_type = OSType.LINUX
             shell = self._detect_unix_shell()
             package_manager = self._detect_linux_package_manager()
+            firewall_tool = self._detect_linux_firewall_tool()
         elif system == "darwin":
             os_type = OSType.MACOS
             shell = self._detect_unix_shell()
-            package_manager = "brew"
+            package_manager = self._detect_macos_package_manager()
+            firewall_tool = "pfctl"
         else:
             os_type = OSType.UNKNOWN
             shell = "sh"
             package_manager = None
-        
+            firewall_tool = None
+
         self._os_info = OSInfo(
             type=os_type,
             name=platform.system(),
             version=platform.version(),
             architecture=platform.machine(),
             shell=shell,
-            package_manager=package_manager
+            package_manager=package_manager,
+            firewall_tool=firewall_tool,
         )
         
         return self._os_info
@@ -98,37 +105,30 @@ class OSDetector:
     
     def _detect_windows_package_manager(self) -> Optional[str]:
         """Detect Windows package manager."""
-        # Check for common Windows package managers
-        managers = ["winget", "choco", "scoop"]
-        for manager in managers:
-            try:
-                subprocess.run([manager, "--version"], 
-                             capture_output=True, timeout=2)
+        for manager in ["winget", "choco", "scoop"]:
+            if shutil.which(manager):
                 return manager
-            except (subprocess.TimeoutExpired, FileNotFoundError):
-                continue
         return None
-    
+
     def _detect_linux_package_manager(self) -> Optional[str]:
         """Detect Linux package manager."""
-        # Check for common Linux package managers in order of preference
-        managers = [
-            ("apt", ["which", "apt"]),
-            ("yum", ["which", "yum"]),
-            ("dnf", ["which", "dnf"]),
-            ("pacman", ["which", "pacman"]),
-            ("zypper", ["which", "zypper"]),
-            ("emerge", ["which", "emerge"]),
-        ]
-        
-        for manager, check_cmd in managers:
-            try:
-                result = subprocess.run(check_cmd, capture_output=True, timeout=1)
-                if result.returncode == 0:
-                    return manager
-            except (subprocess.TimeoutExpired, FileNotFoundError):
-                continue
-        
+        for manager in ["apt", "dnf", "pacman", "yum", "zypper", "emerge"]:
+            if shutil.which(manager):
+                return manager
+        return None
+
+    def _detect_macos_package_manager(self) -> Optional[str]:
+        """Detect macOS package manager."""
+        for manager in ["brew"]:
+            if shutil.which(manager):
+                return manager
+        return None
+
+    def _detect_linux_firewall_tool(self) -> Optional[str]:
+        """Detect Linux firewall tool."""
+        for tool in ["ufw", "nft", "iptables"]:
+            if shutil.which(tool):
+                return tool
         return None
     
     def get_command_mapping(self) -> Dict[str, Dict[str, str]]:
@@ -147,6 +147,28 @@ class OSDetector:
     
     def _get_windows_commands(self) -> Dict[str, Dict[str, str]]:
         """Windows-specific command mappings."""
+        pm = self._os_info.package_manager
+        if pm == "winget":
+            packages = {
+                "install": "winget install",
+                "update": "winget upgrade",
+                "remove": "winget uninstall",
+            }
+        elif pm == "choco":
+            packages = {
+                "install": "choco install",
+                "update": "choco upgrade",
+                "remove": "choco uninstall",
+            }
+        else:
+            packages = {}
+
+        firewall = {
+            "enable": "netsh advfirewall set allprofiles state on",
+            "disable": "netsh advfirewall set allprofiles state off",
+            "status": "netsh advfirewall show allprofiles",
+        }
+
         return {
             "network": {
                 "list_interfaces": "ipconfig /all",
@@ -173,11 +195,57 @@ class OSDetector:
                 "start": "sc start",
                 "stop": "sc stop",
                 "status": "sc queryex",
-            }
+            },
+            "packages": packages,
+            "firewall": firewall,
         }
     
     def _get_linux_commands(self) -> Dict[str, Dict[str, str]]:
         """Linux-specific command mappings."""
+        pm = self._os_info.package_manager
+        if pm == "apt":
+            packages = {
+                "install": "sudo apt install",
+                "update": "sudo apt update",
+                "remove": "sudo apt remove",
+            }
+        elif pm == "dnf":
+            packages = {
+                "install": "sudo dnf install",
+                "update": "sudo dnf update",
+                "remove": "sudo dnf remove",
+            }
+        elif pm == "pacman":
+            packages = {
+                "install": "sudo pacman -S",
+                "update": "sudo pacman -Syu",
+                "remove": "sudo pacman -R",
+            }
+        else:
+            packages = {}
+
+        firewall_tool = self._os_info.firewall_tool or self._detect_linux_firewall_tool()
+        if firewall_tool == "ufw":
+            firewall = {
+                "enable": "sudo ufw enable",
+                "disable": "sudo ufw disable",
+                "status": "sudo ufw status",
+            }
+        elif firewall_tool == "nft":
+            firewall = {
+                "enable": "sudo systemctl start nftables",
+                "disable": "sudo systemctl stop nftables",
+                "status": "sudo nft list ruleset",
+            }
+        elif firewall_tool == "iptables":
+            firewall = {
+                "enable": "sudo systemctl start iptables",
+                "disable": "sudo systemctl stop iptables",
+                "status": "sudo iptables -L",
+            }
+        else:
+            firewall = {}
+
         return {
             "network": {
                 "list_interfaces": "ip addr show",
@@ -204,11 +272,29 @@ class OSDetector:
                 "start": "systemctl start",
                 "stop": "systemctl stop",
                 "status": "systemctl status",
-            }
+            },
+            "packages": packages,
+            "firewall": firewall,
         }
     
     def _get_macos_commands(self) -> Dict[str, Dict[str, str]]:
         """macOS-specific command mappings."""
+        pm = self._os_info.package_manager
+        if pm == "brew":
+            packages = {
+                "install": "brew install",
+                "update": "brew update",
+                "remove": "brew uninstall",
+            }
+        else:
+            packages = {}
+
+        firewall = {
+            "enable": "sudo pfctl -E",
+            "disable": "sudo pfctl -d",
+            "status": "sudo pfctl -s all",
+        }
+
         return {
             "network": {
                 "list_interfaces": "ifconfig",
@@ -217,7 +303,7 @@ class OSDetector:
                 "traceroute": "traceroute",
                 "dns_flush": "sudo dscacheutil -flushcache",
             },
-            "files": {  
+            "files": {
                 "list": "ls",
                 "copy": "cp",
                 "move": "mv",
@@ -235,7 +321,9 @@ class OSDetector:
                 "start": "launchctl start",
                 "stop": "launchctl stop",
                 "status": "launchctl list",
-            }
+            },
+            "packages": packages,
+            "firewall": firewall,
         }
     
     def _get_generic_commands(self) -> Dict[str, Dict[str, str]]:
@@ -254,5 +342,7 @@ class OSDetector:
             "processes": {
                 "list": "ps",
                 "kill": "kill",
-            }
+            },
+            "packages": {},
+            "firewall": {},
         }

--- a/tests/test_os_utils.py
+++ b/tests/test_os_utils.py
@@ -3,120 +3,124 @@ Tests for OS detection utilities.
 """
 
 import pytest
-import platform
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from pilotcmd.os_utils.detector import OSDetector, OSInfo, OSType
 
 
 class TestOSDetector:
     """Tests for OSDetector class."""
-    
+
     def test_detector_initialization(self):
-        """Test OSDetector initialization."""
         detector = OSDetector()
         assert detector._os_info is None
-    
+
     @patch('platform.system')
     def test_windows_detection(self, mock_system):
-        """Test Windows OS detection."""
         mock_system.return_value = "Windows"
-        
+
         with patch.object(OSDetector, '_detect_windows_shell', return_value='powershell'), \
              patch.object(OSDetector, '_detect_windows_package_manager', return_value='winget'):
-            
+
             detector = OSDetector()
             os_info = detector.detect()
-            
+
             assert os_info.type == OSType.WINDOWS
             assert os_info.shell == 'powershell'
             assert os_info.package_manager == 'winget'
-    
+            assert os_info.firewall_tool == 'netsh'
+
     @patch('platform.system')
     def test_linux_detection(self, mock_system):
-        """Test Linux OS detection."""
         mock_system.return_value = "Linux"
-        
+
         with patch.object(OSDetector, '_detect_unix_shell', return_value='bash'), \
-             patch.object(OSDetector, '_detect_linux_package_manager', return_value='apt'):
-            
+             patch.object(OSDetector, '_detect_linux_package_manager', return_value='apt'), \
+             patch.object(OSDetector, '_detect_linux_firewall_tool', return_value='ufw'):
+
             detector = OSDetector()
             os_info = detector.detect()
-            
+
             assert os_info.type == OSType.LINUX
             assert os_info.shell == 'bash'
             assert os_info.package_manager == 'apt'
-    
+            assert os_info.firewall_tool == 'ufw'
+
     @patch('platform.system')
     def test_macos_detection(self, mock_system):
-        """Test macOS detection."""
         mock_system.return_value = "Darwin"
-        
-        with patch.object(OSDetector, '_detect_unix_shell', return_value='zsh'):
+
+        with patch.object(OSDetector, '_detect_unix_shell', return_value='zsh'), \
+             patch.object(OSDetector, '_detect_macos_package_manager', return_value='brew'):
+
             detector = OSDetector()
             os_info = detector.detect()
-            
+
             assert os_info.type == OSType.MACOS
             assert os_info.shell == 'zsh'
             assert os_info.package_manager == 'brew'
-    
+            assert os_info.firewall_tool == 'pfctl'
+
     def test_os_info_methods(self):
-        """Test OSInfo helper methods."""
-        # Windows
         windows_info = OSInfo(
             type=OSType.WINDOWS,
             name="Windows",
             version="10",
             architecture="x64",
-            shell="powershell"
+            shell="powershell",
         )
         assert windows_info.is_windows() is True
         assert windows_info.is_linux() is False
         assert windows_info.is_macos() is False
-        
-        # Linux
+
         linux_info = OSInfo(
             type=OSType.LINUX,
             name="Linux",
             version="5.4.0",
             architecture="x86_64",
-            shell="bash"
+            shell="bash",
         )
         assert linux_info.is_windows() is False
         assert linux_info.is_linux() is True
         assert linux_info.is_macos() is False
-    
+
     def test_command_mappings(self):
-        """Test OS-specific command mappings."""
         detector = OSDetector()
-        
-        # Mock Windows detection
+
         detector._os_info = OSInfo(
             type=OSType.WINDOWS,
             name="Windows",
             version="10",
             architecture="x64",
-            shell="cmd"
+            shell="cmd",
+            package_manager="choco",
+            firewall_tool="netsh",
         )
-        
+
         mappings = detector.get_command_mapping()
         assert "network" in mappings
         assert "ping" in mappings["network"]
         assert mappings["files"]["list"] == "dir"
-        
-        # Mock Linux detection
+        assert mappings["packages"]["install"] == "choco install"
+        assert mappings["firewall"]["status"] == "netsh advfirewall show allprofiles"
+
         detector._os_info = OSInfo(
             type=OSType.LINUX,
             name="Linux",
             version="5.4.0",
             architecture="x86_64",
-            shell="bash"
+            shell="bash",
+            package_manager="apt",
+            firewall_tool="ufw",
         )
-        
+
         mappings = detector.get_command_mapping()
         assert mappings["files"]["list"] == "ls"
         assert mappings["network"]["list_interfaces"] == "ip addr show"
+        assert mappings["packages"]["install"] == "sudo apt install"
+        assert mappings["firewall"]["status"] == "sudo ufw status"
 
 
 if __name__ == "__main__":
     pytest.main([__file__])
+


### PR DESCRIPTION
## Summary
- detect package managers and firewall tools across Linux/macOS/Windows
- provide unified command mappings for packages and firewalls
- document cross-platform command equivalents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec261edb483218427d0e282963c07